### PR TITLE
Move library into a SDL subfolder to avoid collision of library

### DIFF
--- a/CloudyGameThinClient/CloudyGameThinClient.vcxproj
+++ b/CloudyGameThinClient/CloudyGameThinClient.vcxproj
@@ -40,8 +40,8 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <IncludePath>$(SolutionDir)\Library\include;$(IncludePath)</IncludePath>
-    <LibraryPath>$(SolutionDir)\Library\lib\win32;$(LibraryPath)</LibraryPath>
+    <IncludePath>$(SolutionDir)Library\SDL\include;$(IncludePath)</IncludePath>
+    <LibraryPath>$(SolutionDir)Library\SDL\lib\win32;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This is an application that the player uses to play the game. The player will re
 The application is developed on Visual Studio 2013. Follow [this tutorial](http://lazyfoo.net/tutorials/SDL/01_hello_SDL/windows/msvsnet2010u/index.php) to set up Visual Studio 2013 to work with SDL. You can download the development library files [here](https://www.libsdl.org/download-2.0.php) (SDL2-devel-2.0.3-VC.zip).
 
 The library files should be placed in the following directories:
-- \Library\include
-- \Library\lib\x86
+- \Library\SDL\include
+- \Library\SDL\lib\x86
 
 Also, SDL.dll is needed to run the application. Put it either your project's working directory, or inside of the system directory (C:\WINDOWS\SYSTEM32).
 


### PR DESCRIPTION
This closes #1 

- Move library into a SDL subfolder to avoid collision of library
- commit Library folder, but still ignoring the content.
- Update docs