### PR TITLE
thin_client get port and ip from launcher

### DIFF
--- a/thin_client.py
+++ b/thin_client.py
@@ -154,21 +154,14 @@ def initializePygame(FPS):
     pygame.display.update()
 
 # Taken from https://gist.github.com/smathot/1521059 with modifications
-def initializeStream(playerControllerID):
+def initializeStream(IP, port):
     # Tested formats: rtmp, rtsp, http
     # Get more test links here: http://www.vlc.eu.pn/
     # http://futuretv.cdn.mangomolo.com/futuretv/smil:futuretv.smil/gmswf.m3u8
     # rtmp://wowza-bnr.cdp.triple-it.nl/bnr/BNRstudio1
     # rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mov
-
-    if (playerControllerID == 0):
-        movieAddress = "http://localhost:30000"
-    elif (playerControllerID == 1):
-        movieAddress = "http://localhost:30001"
-    elif (playerControllerID == 2):
-        movieAddress = "http://localhost:30002"
-    elif (playerControllerID == 3):
-        movieAddress = "http://localhost:30003"
+   
+    movieAddress = "http://" + IP + ":" + port
 
     # Create instane of VLC and create reference to movieAddress.
     vlcInstance = vlc.Instance()
@@ -200,7 +193,7 @@ def initializeStream(playerControllerID):
     # Start movieAddress playback
     player.play()
     
-def startClient(playerControllerID):
+def startClient(IP, port, playerControllerID):
     sequence = 0
     print("UDP target IP:", UDP_IP)
     print("UDP target port:", UDP_PORT)
@@ -209,7 +202,7 @@ def startClient(playerControllerID):
                          socket.SOCK_DGRAM) # UDP
 
     initializePygame(30) #FPS
-    initializeStream(playerControllerID)
+    initializeStream(IP, port)
     isRunning = True
     isMouseGrabbed = True
 
@@ -275,13 +268,14 @@ def startClient(playerControllerID):
 
     pygame.quit()
 
-def main(playerControllerID):
-    startClient(playerControllerID)
+def main(IP, port, playerControllerID):
+    startClient(IP, port, int(playerControllerID))
     
 if __name__ == '__main__':
     # If an argument is passed with the script
-    if len(sys.argv) > 1:
-        main(sys.argv[1])
-    # If no argument, launch with playerControllerID as 0
+    # [IP, port, controllerID]
+    if len(sys.argv) > 3:
+        main(sys.argv[1], sys.argv[2], sys.argv[3])
+    # If none or missing argument, launch with these defaults
     else:
-        main(0)
+        main("127.0.0.1", 30000, 0)

--- a/thin_client.py
+++ b/thin_client.py
@@ -112,9 +112,9 @@ i = signed int (4 bytes)
 """
 PACKET_FORMAT_KEY = "=BBIBIIB"
 PACKET_FORMAT_MOUSE = "=BBIBii"
-UDP_IP = "127.0.0.1"
+UDP_IP = "127.0.0.1" # Connection to Remote Controller
 UDP_PORT = 55555
-TCP_IP = "127.0.0.1"
+TCP_IP = "127.0.0.1" # Connection to CPP
 TCP_PORT = 55556
 VERSION = 0
 RESO_WIDTH = 640
@@ -161,7 +161,8 @@ def initializeStream(IP, port):
     # rtmp://wowza-bnr.cdp.triple-it.nl/bnr/BNRstudio1
     # rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mov
    
-    movieAddress = "http://" + IP + ":" + port
+    movieAddress = "http://" + str(IP) + ":" + str(port)
+    print (movieAddress)
 
     # Create instane of VLC and create reference to movieAddress.
     vlcInstance = vlc.Instance()
@@ -254,12 +255,11 @@ def startClient(IP, port, playerControllerID):
             print(pygame.mouse.get_pressed(), "=>", UEKeyCode)
             
         if (event.type == QUIT):
-            QUIT_MESSAGE = "quit_client"
-            MESSAGE_BYTE = QUIT_MESSAGE.encode("utf-8")
+            quitCommand = "0001000" + str(playerControllerID)
             try:
                 cpsocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 cpsocket.connect((TCP_IP, TCP_PORT))
-                cpsocket.sendall(MESSAGE_BYTE)
+                cpsocket.sendall(quitCommand.encode("utf-8"))
             except socket.error as error:
                 print("Thin client:", os.strerror(error.errno));
             finally:


### PR DESCRIPTION
Can now pass ip, port, and playerControllerID to thin client.

Usage:
`python thin_client.py 127.0.0.1 30000 0`

If you prefer to pass the IP with the http://, I can do that too